### PR TITLE
Fix gh-pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ "main" ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- enable repo write access for GitHub Pages deployment

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687facc834c0832fb8b67cdcda409563